### PR TITLE
ModuleNotFoundError: No module named 'openalea.visualea.qt'

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 test:
   imports:
     - openalea.visualea
+    - openalea.visualea.qt
 
 about:
   home: {{ data.get('url') }}

--- a/src/openalea/visualea/version.py
+++ b/src/openalea/visualea/version.py
@@ -11,7 +11,7 @@ MAJOR = 2
 MINOR = 3
 """(int) Version minor component."""
 
-POST = 0
+POST = 1
 """(int) Version post or bugfix component."""
 
 __version__ = ".".join([str(s) for s in (MAJOR, MINOR, POST)])


### PR DESCRIPTION
__init__.py was missing in `openalea.visualea.qt` package