### PR TITLE
Visualea do not run on windows

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ..
 
 build:
-  noarch: python
+  #noarch: python,# issue 37
   preserve_egg_dir: True
   number: 1
   script: {{PYTHON}} setup.py install


### PR DESCRIPTION
Do not generate pure Python package.
Visualea.exe is not correctly generated.

Build a specific package for each OS.

Close issue #37